### PR TITLE
Fixes issue with BEM-named snippets register as jssnippets

### DIFF
--- a/build/tdcss.js
+++ b/build/tdcss.js
@@ -169,7 +169,10 @@
                 for (var fragment_type in settings.fragment_types) {
                     if (settings.fragment_types.hasOwnProperty(fragment_type)) {
                         var identifier = settings.fragment_types[fragment_type].identifier;
-                        if (that.raw_comment_node.nodeValue.match(new RegExp(identifier))) {
+
+                        //Only match if it's at beginning of comment or preceeded by spaces
+                        var regex = new RegExp('^\\s*' + identifier);
+                        if (that.raw_comment_node.nodeValue.match(regex)) {
                             found_type = fragment_type;
                         }
                     }

--- a/demo/index.html
+++ b/demo/index.html
@@ -63,7 +63,6 @@
     $('#coffee').append '<h1>Test from coffeescript</h1>'
 </script>
 
-
 <!-- # Box styles -->
 <!-- & Box styles is a collection of generic boxes. -->
 

--- a/src/tdcss.js
+++ b/src/tdcss.js
@@ -170,7 +170,10 @@
                 for (var fragment_type in settings.fragment_types) {
                     if (settings.fragment_types.hasOwnProperty(fragment_type)) {
                         var identifier = settings.fragment_types[fragment_type].identifier;
-                        if (that.raw_comment_node.nodeValue.match(new RegExp(identifier))) {
+
+                        //Only match if it's at beginning of comment or preceeded by spaces
+                        var regex = new RegExp('^\\s*' + identifier);
+                        if (that.raw_comment_node.nodeValue.match(regex)) {
                             found_type = fragment_type;
                         }
                     }

--- a/test/spec/javascripts/fixtures/html/bem-bug.html
+++ b/test/spec/javascripts/fixtures/html/bem-bug.html
@@ -1,0 +1,7 @@
+
+  <div id="tdcss">
+    <!-- # BEM__test -->
+    <!-- no__identifier__with__underscores--and--hyphens -->
+  </div>
+
+

--- a/test/spec/spec.js
+++ b/test/spec/spec.js
@@ -61,6 +61,15 @@ describe("TDCSS", function () {
             expect(tdcss[0].fragments[0].type).toBe("section");
             expect(tdcss[0].fragments[1].type).toBe("snippet");
         });
+
+        it("should only match on first non-space character", function () {
+            loadFixtures('bem-bug.html');
+            $("#tdcss").tdcss();
+
+            expect(tdcss[0].fragments.length).toBe(2);
+            expect(tdcss[0].fragments[0].type).toBe("section");
+            expect(tdcss[0].fragments[1].type).toBe("");
+        });
     });
 
     describe("Rendering", function () {


### PR DESCRIPTION
I believe this should fix https://github.com/jakobloekke/tdcss.js/issues/27 and only match on the first non-space character from the beginning of comment. Fwiw, I actually ran in to this with a long comment that contained another fragment type.