### PR TITLE
Header top setting

### DIFF
--- a/build/tdcss.js
+++ b/build/tdcss.js
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-03-30
+/* tdcss.js - v0.8.1 - 2016-04-13
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */
@@ -69,7 +69,7 @@
             }
 
             if (module.theme.setup !== undefined) {
-                module.theme.setup();
+                module.theme.setup(settings);
             }
 
             window.tdcss = window.tdcss || [];

--- a/build/themes/original/tdcss.css
+++ b/build/themes/original/tdcss.css
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-03-30
+/* tdcss.js - v0.8.1 - 2016-04-13
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */

--- a/build/themes/original/theme.js
+++ b/build/themes/original/theme.js
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-03-30
+/* tdcss.js - v0.8.1 - 2016-04-13
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */

--- a/build/themes/sidebar/tdcss.css
+++ b/build/themes/sidebar/tdcss.css
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-03-30
+/* tdcss.js - v0.8.1 - 2016-04-13
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */
@@ -37,13 +37,13 @@ body {
 }
 .tdcss-header {
   background-color: #333;
-  height: 120px;
+  height: 100px;
 }
 #logo {
   width: 20%;
   float: left;
   margin-left: 40px;
-  line-height: 120px;
+  line-height: 100px;
 }
 #logo a {
   text-decoration: none;

--- a/build/themes/sidebar/theme.js
+++ b/build/themes/sidebar/theme.js
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-03-30
+/* tdcss.js - v0.8.1 - 2016-04-13
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */
@@ -65,7 +65,7 @@ if (typeof tdcss_theme !== 'function') {
                 $('.tdcss-toggle-link').append(makeHTMLToggle());
             },
 
-            setupAccordian: function () {
+            setupAccordian: function (settings) {
 
                 function toggleAccordion(li) {
                     var dur = 250;
@@ -92,9 +92,13 @@ if (typeof tdcss_theme !== 'function') {
 
             },
 
-            setupStickySidebar: function() {
+            setupStickySidebar: function(settings) {
                 var sidebarMarginTop = 64;
+
                 var headerTop = 120;
+                if (settings.headerTop !== undefined) {
+                    headerTop = settings.headerTop;
+                }
 
                 //Grab the offset locations of links
                 var locationsInPage = [];
@@ -162,7 +166,7 @@ if (typeof tdcss_theme !== 'function') {
                 });
             },
 
-            setup: function () {
+            setup: function (settings) {
                 var self = this;
 
                 //Wrap the .tdcss-elements and .tdd-navigation (which are adjacent) in container
@@ -172,8 +176,8 @@ if (typeof tdcss_theme !== 'function') {
 
                 //Sets up the Accordian / Sticky Sidebar on document loaded
                 $(function(){ 
-                    _private.setupAccordian();
-                    _private.setupStickySidebar();
+                    _private.setupAccordian(settings);
+                    _private.setupStickySidebar(settings);
                 });
             }
         };

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,9 @@
 
     <script type="text/javascript">
         $(function () {
-            $("#tdcss").tdcss({});
+            $("#tdcss").tdcss({
+                headerTop: 100 
+            });
         });
     </script>
 

--- a/src/tdcss.js
+++ b/src/tdcss.js
@@ -70,7 +70,7 @@
             }
 
             if (module.theme.setup !== undefined) {
-                module.theme.setup();
+                module.theme.setup(settings);
             }
 
             window.tdcss = window.tdcss || [];

--- a/src/themes/sidebar/tdcss.css
+++ b/src/themes/sidebar/tdcss.css
@@ -38,13 +38,13 @@ body {
 }
 .tdcss-header {
   background-color: #333;
-  height: 120px;
+  height: 100px;
 }
 #logo {
   width: 20%;
   float: left;
   margin-left: 40px;
-  line-height: 120px;
+  line-height: 100px;
 }
 #logo a {
   text-decoration: none;

--- a/src/themes/sidebar/theme.js
+++ b/src/themes/sidebar/theme.js
@@ -1,3 +1,9 @@
+/* tdcss.js - v0.8.1 - 2016-03-30
+* http://jakobloekke.github.io/tdcss.js/
+* Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
+* License: MIT */
+
+
 if (typeof tdcss_theme !== 'function') {
 
     tdcss_theme = (function () {
@@ -59,7 +65,7 @@ if (typeof tdcss_theme !== 'function') {
                 $('.tdcss-toggle-link').append(makeHTMLToggle());
             },
 
-            setupAccordian: function () {
+            setupAccordian: function (settings) {
 
                 function toggleAccordion(li) {
                     var dur = 250;
@@ -86,9 +92,13 @@ if (typeof tdcss_theme !== 'function') {
 
             },
 
-            setupStickySidebar: function() {
+            setupStickySidebar: function(settings) {
                 var sidebarMarginTop = 64;
+
                 var headerTop = 120;
+                if (settings.headerTop !== undefined) {
+                    headerTop = settings.headerTop;
+                }
 
                 //Grab the offset locations of links
                 var locationsInPage = [];
@@ -156,7 +166,7 @@ if (typeof tdcss_theme !== 'function') {
                 });
             },
 
-            setup: function () {
+            setup: function (settings) {
                 var self = this;
 
                 //Wrap the .tdcss-elements and .tdd-navigation (which are adjacent) in container
@@ -166,8 +176,8 @@ if (typeof tdcss_theme !== 'function') {
 
                 //Sets up the Accordian / Sticky Sidebar on document loaded
                 $(function(){ 
-                    _private.setupAccordian();
-                    _private.setupStickySidebar();
+                    _private.setupAccordian(settings);
+                    _private.setupStickySidebar(settings);
                 });
             }
         };


### PR DESCRIPTION
This PR adds capability to pass in an option `headerTop: SIZE` for the sidebar theme. Use case is that our styleguide's design called for a much bigger header then the theme default, and the variable is used to control the sticky sidebar, so, simple solution was to add as option.