### PR TITLE
Fix issue where you jump to a link, and there's an extra 50px padding…

### DIFF
--- a/src/themes/sidebar/theme.js
+++ b/src/themes/sidebar/theme.js
@@ -174,8 +174,6 @@ if (typeof tdcss_theme !== 'function') {
 
                         //Add the subnav height and scrolling adjustment to current Y so the left nav
                         //active links are updated when the section bar is a few pixels below subnav
-
-
                         if (y + extraPadding >= loc - scrollingAdjustment) {
                             $('.tdcss-nav li').removeClass('active').eq(i).addClass('active');
                         }

--- a/src/themes/sidebar/theme.js
+++ b/src/themes/sidebar/theme.js
@@ -174,6 +174,8 @@ if (typeof tdcss_theme !== 'function') {
 
                         //Add the subnav height and scrolling adjustment to current Y so the left nav
                         //active links are updated when the section bar is a few pixels below subnav
+
+
                         if (y + extraPadding >= loc - scrollingAdjustment) {
                             $('.tdcss-nav li').removeClass('active').eq(i).addClass('active');
                         }
@@ -196,7 +198,7 @@ if (typeof tdcss_theme !== 'function') {
                     var target = $(href);
 
                     $('html, body').stop().animate({
-                        'scrollTop': target.offset().top - 50
+                        'scrollTop': target.offset().top
                     }, 600, 'swing', function () {});
                 }
             },


### PR DESCRIPTION
Fix issue where you jump to a link, and there's an extra 50px padding above the target. It also causes an issue with the sticky sidebar active highlighting; you still have to scroll a bit for the new targetted section to get the blue border right.