### PR TITLE
put coffeescript eval in try catch so doesn't stop execution of other…

### DIFF
--- a/src/tdcss.js
+++ b/src/tdcss.js
@@ -361,7 +361,11 @@
 
             //We wait until here since we've now appended the $row to our module container
             if (fragment.type === 'coffeesnippet' && window.CoffeeScript) {
-                window.CoffeeScript.eval(fragment.raw_script);
+                try {
+                    window.CoffeeScript.eval(fragment.raw_script);
+                } catch (err) {
+                    console.log("TDCSS error caught for: " + fragment + ". Error: " + err);
+                }
             }
 
 


### PR DESCRIPTION
… snippets if error. Also, logs error so we can potentially look at the error.stack etc., for debugging purposes.