### PR TITLE
Adds a rowHeight setting for sidebar theme. Caller can provide to hav…

### DIFF
--- a/build/tdcss.js
+++ b/build/tdcss.js
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-09-21
+/* tdcss.js - v0.8.1 - 2016-11-02
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */
@@ -21,6 +21,7 @@
                 },
                 fragment_info_splitter: ";",
                 replacementContent: "...",
+                rowHeight: null,
                 hideTextContent: false,
                 setCollapsedStateInUrl: true,
                 hideTheseAttributesContent: [

--- a/build/themes/original/tdcss.css
+++ b/build/themes/original/tdcss.css
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-09-21
+/* tdcss.js - v0.8.1 - 2016-11-02
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */

--- a/build/themes/original/theme.js
+++ b/build/themes/original/theme.js
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-09-21
+/* tdcss.js - v0.8.1 - 2016-11-02
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */

--- a/build/themes/sidebar/tdcss.css
+++ b/build/themes/sidebar/tdcss.css
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-09-21
+/* tdcss.js - v0.8.1 - 2016-11-02
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */

--- a/build/themes/sidebar/theme.js
+++ b/build/themes/sidebar/theme.js
@@ -1,4 +1,4 @@
-/* tdcss.js - v0.8.1 - 2016-09-21
+/* tdcss.js - v0.8.1 - 2016-11-02
 * http://jakobloekke.github.io/tdcss.js/
 * Copyright (c) 2016 Jakob Løkke Madsen <jakob@jakobloekkemadsen.com> (http://www.jakobloekkemadsen.com);
 * License: MIT */
@@ -126,6 +126,56 @@ if (typeof tdcss_theme !== 'function') {
                         settings.onAccordionActivated(li);
                     }
                 }
+
+                _private.adjustScrollingCategory(settings, li); 
+            },
+
+            //Provides an affordance that there are more sections available within an
+            //open category in the Accordian. Essentially, it will adjust the height
+            //such that there's an extra half of a row, giving the user a clue that more
+            //sections are available if they scroll (similar to how a carousel player might
+            //show half of a thumbnail)
+            adjustScrollingCategory: function (settings, li) {
+
+                //We only can adjust the scrollable category accordian area if a row height
+                //has been provided.
+                if (!settings.rowHeight) {
+                    return;
+                }
+
+                //Reset min/max heights to their original values
+                $('.tdcss-nav-category').css('min-height', 0);
+
+                //This reset must reflect the CSS set in the theme/tdcss.css:
+                //.tdcss-navigation ul { max-height: 60% ...
+                $('.tdcss-nav-category').css('max-height', '60%');
+
+
+                // We calculate the scroll height vs. offset height.
+                // If greater we have scrollbar and we adjust the min or max
+                // height of the list to cause a half row overlap affordance
+                setTimeout(function() {
+                    var tdcssNavCategory = $(li).parent();
+                    var scrollHeight = $(tdcssNavCategory)[0].scrollHeight;
+                    var offsetHeight = $(tdcssNavCategory)[0].offsetHeight;
+
+                    if (scrollHeight > offsetHeight) {
+                        var height = parseInt( $(tdcssNavCategory).css('height'));
+
+                        // Create a half row extra height
+                        var rowHeight = settings.rowHeight;
+                        var half = rowHeight/2;
+                        var leftover = height % rowHeight;
+
+                        var additional = parseInt (half - leftover);
+                        if (leftover > half) {
+                            additional = parseInt(leftover - half);
+                            $(tdcssNavCategory).css('max-height', height - additional);
+                        } else {
+                            $(tdcssNavCategory).css('min-height', height + additional);
+                        }
+                    }
+                }, 200);
             },
 
             setupAccordian: function (settings) {

--- a/src/tdcss.js
+++ b/src/tdcss.js
@@ -22,6 +22,7 @@
                 },
                 fragment_info_splitter: ";",
                 replacementContent: "...",
+                rowHeight: null,
                 hideTextContent: false,
                 setCollapsedStateInUrl: true,
                 hideTheseAttributesContent: [

--- a/src/themes/sidebar/theme.js
+++ b/src/themes/sidebar/theme.js
@@ -126,6 +126,56 @@ if (typeof tdcss_theme !== 'function') {
                         settings.onAccordionActivated(li);
                     }
                 }
+
+                _private.adjustScrollingCategory(settings, li); 
+            },
+
+            //Provides an affordance that there are more sections available within an
+            //open category in the Accordian. Essentially, it will adjust the height
+            //such that there's an extra half of a row, giving the user a clue that more
+            //sections are available if they scroll (similar to how a carousel player might
+            //show half of a thumbnail)
+            adjustScrollingCategory: function (settings, li) {
+
+                //We only can adjust the scrollable category accordian area if a row height
+                //has been provided.
+                if (!settings.rowHeight) {
+                    return;
+                }
+
+                //Reset min/max heights to their original values
+                $('.tdcss-nav-category').css('min-height', 0);
+
+                //This reset must reflect the CSS set in the theme/tdcss.css:
+                //.tdcss-navigation ul { max-height: 60% ...
+                $('.tdcss-nav-category').css('max-height', '60%');
+
+
+                // We calculate the scroll height vs. offset height.
+                // If greater we have scrollbar and we adjust the min or max
+                // height of the list to cause a half row overlap affordance
+                setTimeout(function() {
+                    var tdcssNavCategory = $(li).parent();
+                    var scrollHeight = $(tdcssNavCategory)[0].scrollHeight;
+                    var offsetHeight = $(tdcssNavCategory)[0].offsetHeight;
+
+                    if (scrollHeight > offsetHeight) {
+                        var height = parseInt( $(tdcssNavCategory).css('height'));
+
+                        // Create a half row extra height
+                        var rowHeight = settings.rowHeight;
+                        var half = rowHeight/2;
+                        var leftover = height % rowHeight;
+
+                        var additional = parseInt (half - leftover);
+                        if (leftover > half) {
+                            additional = parseInt(leftover - half);
+                            $(tdcssNavCategory).css('max-height', height - additional);
+                        } else {
+                            $(tdcssNavCategory).css('min-height', height + additional);
+                        }
+                    }
+                }, 200);
             },
 
             setupAccordian: function (settings) {


### PR DESCRIPTION
Provides an affordance that there are more sections available within an open category in the Accordian. Essentially, it will adjust the height such that there's an extra half of a row, giving the user a clue that more sections are available if they scroll (similar to how a carousel player might show half of a thumbnail).

The following screenshot of tdcss sidebar theme tells the story better than above paragraph:

![screen shot 2016-11-02 at 9 49 36 am](https://cloud.githubusercontent.com/assets/142403/19938654/f234f46e-a0e2-11e6-87e9-ec7f66165cfa.png)

Here's a screenshot of how it's looking in the Mavenlink application. Notice the Datepicker section is half shown (like a carousel would do):

<img width="113" alt="screen shot 2016-11-02 at 9 59 45 am" src="https://cloud.githubusercontent.com/assets/142403/19938701/256cccc6-a0e3-11e6-9050-ceb406fb4e48.png">
